### PR TITLE
Fix/12345 fix registry cleaning

### DIFF
--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -18,42 +18,44 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const org    = context.repo.owner;
-            const pkg    = 'MY_PACKAGE_NAME';    // Replace with your container package name
+            const org = context.repo.owner;
+            const pkg = 'MY_PACKAGE_NAME';    // ← replace with your package name
 
-            // SemVer regex:
-            //  • optional leading “v”  
-            //  • major required, minor & patch optional  
-            //  • optional prerelease (-…) and build metadata (+…)  
-
+            // same flexible SemVer regex as before
             const semver = /^v?(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
             let page = 1;
-
             while (true) {
-              const { data: versions } = await github.rest.packages.listPackageVersionsForOrg({
-                package_type: 'container',
-                package_name: pkg,
-                org,
-                per_page: 100,
-                page
-              });
+              // LIST versions via raw REST call
+              const { data: versions } = await github.request(
+                'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
+                {
+                  org,
+                  package_type: 'container',
+                  package_name: pkg,
+                  per_page: 100,
+                  page
+                }
+              );
 
               if (versions.length === 0) break;
 
               for (const v of versions) {
                 const tags = v.metadata.container.tags || [];
 
-                // Keep if any tag is SemVer or 'main'
+                // skip if any tag is SemVer or "main"
                 if (tags.some(t => semver.test(t) || t === 'main')) continue;
 
-                // Delete all others
-                await github.rest.packages.deletePackageVersionForOrg({
-                  package_type: 'container',
-                  package_name: pkg,
-                  org,
-                  package_version_id: v.id
-                });
+                // DELETE the version via raw REST call
+                await github.request(
+                  'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
+                  {
+                    org,
+                    package_type: 'container',
+                    package_name: pkg,
+                    package_version_id: v.id
+                  }
+                );
 
                 console.log(`Deleted version ${v.id} (tags: ${tags.join(', ')})`);
               }

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -13,54 +13,86 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 🧹 List & delete outdated versions
+      - name: 🧹 List & delete outdated versions for all syn2real/* packages
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const org = context.repo.owner;
-            const pkg = 'MY_PACKAGE_NAME';    // ← replace with your package name
+            const org    = context.repo.owner
+            // Target packages under "<repo>/…"
+            const prefix = `${repo}/`
 
-            // same flexible SemVer regex as before
-            const semver = /^v?(0|[1-9]\d*)(?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+            // Flexible SemVer: optional leading “v”, optional minor/patch, prerelease/build
+            const semver = /^v?(0|[1-9]\d*)?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/x
 
-            let page = 1;
+            // 1️⃣ List all container packages, filter by prefix
+            let pkgPage = 1
+            const pkgNames = []
+
             while (true) {
-              // LIST versions via raw REST call
-              const { data: versions } = await github.request(
-                'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
+              const { data: pkgs } = await github.request(
+                'GET /orgs/{org}/packages',
                 {
                   org,
                   package_type: 'container',
-                  package_name: pkg,
                   per_page: 100,
-                  page
+                  page: pkgPage
                 }
-              );
+              )
 
-              if (versions.length === 0) break;
+              if (!pkgs.length) break
 
-              for (const v of versions) {
-                const tags = v.metadata.container.tags || [];
+              for (const p of pkgs) {
+                if (p.name.startsWith(prefix)) {
+                  pkgNames.push(p.name)
+                }
+              }
 
-                // skip if any tag is SemVer or "main"
-                if (tags.some(t => semver.test(t) || t === 'main')) continue;
+              pkgPage++
+            }
 
-                // DELETE the version via raw REST call
-                await github.request(
-                  'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
+            // 2️⃣ For each matching package, list versions & delete non-SemVer/non-main
+            for (const pkg of pkgNames) {
+              let verPage = 1
+
+              while (true) {
+                const { data: versions } = await github.request(
+                  'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
                   {
                     org,
                     package_type: 'container',
                     package_name: pkg,
-                    package_version_id: v.id
+                    per_page: 100,
+                    page: verPage
                   }
-                );
+                )
 
-                console.log(`Deleted version ${v.id} (tags: ${tags.join(', ')})`);
+                if (!versions.length) break
+
+                for (const v of versions) {
+                  const tags = v.metadata.container.tags || []
+
+                  // Keep if any tag matches SemVer or is 'main'
+                  if (tags.some(t => semver.test(t) || t === 'main')) {
+                    continue
+                  }
+
+                  // Otherwise delete it
+                  await github.request(
+                    'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
+                    {
+                      org,
+                      package_type: 'container',
+                      package_name: pkg,
+                      package_version_id: v.id
+                    }
+                  )
+
+                  console.log(`Deleted ${pkg}@${v.id} (tags: ${tags.join(', ')})`)
+                }
+
+                verPage++
               }
-
-              page++;
             }
 
       - name: 📝 Cleanup job summary

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -1,4 +1,4 @@
-name: 🧹 Docker registry weekly clean-Up
+name: 🧹 Docker registry weekly cleanup
 
 on:
   schedule:
@@ -95,22 +95,37 @@ jobs:
   aggregate-summary:
     needs: cleanup
     runs-on: ubuntu-latest
-    name: 📝 Aggregate summary
+    name: 📝 Aggregated results
     steps:
       - name: 📥 Download all deleted‐entries artifacts
         uses: actions/download-artifact@v4
         with:
           path: deleted_entries
 
-      - name: 📝 Weekly cleanup aggregate summary
+      - name: 📝 Cleanup summary
         run: |
-          echo "## 🗑️ Weekly Cleanup Aggregate Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "## 🗑️ Cleanup Summary" >> "$GITHUB_STEP_SUMMARY"
 
-          # concat all deleted.txt files
-          all=$(find deleted_entries -type f -exec cat {} +)
+          # Combine all deleted entries into one list
+          all=$(find deleted_entries -type f -name 'deleted.txt' -exec cat {} +)
 
           if [ -z "$all" ]; then
-            echo "✨ **No images deleted** ✨" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "$all" | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
+            echo "✨ **No images deleted this week** ✨" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
+
+          # Group by service
+          echo "$all" | awk -F'@' '
+            {
+              # split "repo/service@id (tags)" on "@"
+              svc_version=$2
+              split($0, a, "@"); svc=a[1]
+              # gather lines per service
+              lines[svc] = lines[svc] "\n- **" svc_version
+            }
+            END {
+              for (s in lines) {
+                print "\n### " s lines[s] "\n"
+              }
+            }
+          ' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch: # Manual trigger
 
 permissions:
-  packages: write # Needed to delete versions
+  packages: write # <-- must be 'delete' to remove versions
+  contents: read # needed if listing repository contents
 
 jobs:
   cleanup:

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const core = require('@actions/core');
             const { owner, repo } = context.repo;
             const pkgName = `${repo}/${process.env.SERVICE}`;
 

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             const org    = context.repo.owner
             // Target packages under "<repo>/…"
-            const prefix = `${repo}/`
+            const prefix = `context.repo.repo/`
 
             // Flexible SemVer regex (single-line, no unsupported flags):
             //  • optional leading "v"

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: # Manual trigger
 
 permissions:
-  packages: write # <-- must be 'delete' to remove versions
+  packages: write # <-- must be write to remove versions
   contents: read # needed if listing repository contents
 
 jobs:
@@ -25,9 +25,6 @@ jobs:
           - gan
 
     steps:
-      - name: 🐳 Checkout code
-        uses: actions/checkout@v3
-
       - name: 🔒 Login to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -34,7 +34,6 @@ jobs:
                 {
                   org: owner,
                   package_type: 'container',
-                  per_page: 100,
                   page: pkgPage
                 }
               );
@@ -56,7 +55,6 @@ jobs:
                     org: owner,
                     package_type: 'container',
                     package_name: pkgName,
-                    per_page: 100,
                     page: verPage
                   }
                 );

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             // ① Destructure owner & repo
             const { owner, repo } = context.repo;
-            const prefix         = `${repo}/`;
+            const prefix          = `${repo}/`;
 
             // ② Flexible SemVer regex
             const semver = /^v?(0|[1-9]\d*)(\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   cleanup:
+    name: 🧹 Clean up registry
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -94,7 +95,7 @@ jobs:
   aggregate-summary:
     needs: cleanup
     runs-on: ubuntu-latest
-
+    name: 📝 Aggregate summary
     steps:
       - name: 📥 Download all deleted‐entries artifacts
         uses: actions/download-artifact@v4
@@ -109,7 +110,7 @@ jobs:
           all=$(find deleted_entries -type f -exec cat {} +)
 
           if [ -z "$all" ]; then
-            echo "- ✨ **No images deleted this week** ✨" >> "$GITHUB_STEP_SUMMARY"
+            echo "✨ **No images deleted** ✨" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "$all" | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -22,8 +22,11 @@ jobs:
             // Target packages under "<repo>/…"
             const prefix = `${repo}/`
 
-            // Flexible SemVer: optional leading “v”, optional minor/patch, prerelease/build
-            const semver = /^v?(0|[1-9]\d*)?:\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/x
+            // Flexible SemVer regex (single-line, no unsupported flags):
+            //  • optional leading "v"
+            //  • major required; minor & patch optional
+            //  • optional prerelease (-...) and build metadata (+...)
+            const semver = /^v?(0|[1-9]\d*)(\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
             // 1️⃣ List all container packages, filter by prefix
             let pkgPage = 1

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -16,12 +16,12 @@ jobs:
       matrix:
         service:
           - baseline
-          - controlnet
+          # - controlnet
           - blip
           - mlflow
           - deepfloyd
           - sdxl
-          - eval
+          # - eval
           - gan
 
     steps:
@@ -33,19 +33,23 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🧹 Clean up images for ${{ matrix.service }}
+        id: cleanup
         uses: actions/github-script@v7
         env:
-          SERVICE: ${{ matrix.service }} # ← on expose la valeur ici
+          SERVICE: ${{ matrix.service }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const core = require('@actions/core');
             const { owner, repo } = context.repo;
-            const pkgName         = `${repo}/${process.env.SERVICE}`;
+            const pkgName = `${repo}/${process.env.SERVICE}`;
 
             // Flexible SemVer: optional "v", optional minor/patch, prerelease/build
             const semver = /^v?(0|[1-9]\d*)(\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
             let page = 1;
+            const deleted = [];
+
             while (true) {
               const { data: versions } = await github.request(
                 'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
@@ -71,7 +75,42 @@ jobs:
                     package_version_id: v.id
                   }
                 );
-                console.log(`Deleted ${pkgName}@${v.id} (tags: ${tags.join(', ')})`);
+                deleted.push(`${pkgName}@${v.id} (${tags.join(', ')})`);
               }
               page++;
             }
+
+            core.setOutput('deleted', deleted.join('\n'));
+
+      - name: Save deleted entries to file
+        run: |
+          echo "${{ steps.cleanup.outputs.deleted }}" > deleted.txt
+
+      - name: 📦 Upload deleted entries
+        uses: actions/upload-artifact@v3
+        with:
+          name: deleted-entries-${{ matrix.service }}
+          path: deleted.txt
+
+  aggregate-summary:
+    needs: cleanup
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Download all deleted‐entries artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: deleted_entries
+
+      - name: 📝 Weekly cleanup aggregate summary
+        run: |
+          echo "## 🗑️ Weekly Cleanup Aggregate Summary" >> "$GITHUB_STEP_SUMMARY"
+
+          # concat all deleted.txt files
+          all=$(find deleted_entries -type f -exec cat {} +)
+
+          if [ -z "$all" ]; then
+            echo "- ✨ **No images deleted this week** ✨" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "$all" | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -47,40 +47,6 @@ jobs:
 
             console.log(pkgNames);
 
-            // 2️⃣ For each package, purge non‐SemVer & non‐main versions
-            for (const pkgName of pkgNames) {
-              let verPage = 1;
-              while (true) {
-                const { data: versions } = await github.request(
-                  'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
-                  {
-                    org: owner,
-                    package_type: 'container',
-                    package_name: pkgName,
-                    page: verPage
-                  }
-                );
-                if (!versions.length) break;
-                for (const v of versions) {
-                  const tags = v.metadata.container.tags || [];
-                  // Keep if any tag is SemVer or 'main'
-                  if (tags.some(t => semver.test(t) || t === 'main')) continue;
-                  // Otherwise delete
-                  await github.request(
-                    'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
-                    {
-                      org: owner,
-                      package_type: 'container',
-                      package_name: pkgName,
-                      package_version_id: v.id
-                    }
-                  );
-                  console.log(`Deleted ${pkgName}@${v.id} (tags: ${tags.join(', ')})`);
-                }
-                verPage++;
-              }
-            }
-
       - name: 📝 Cleanup job summary
         run: |
           echo "### 🧹 Docker registry cleanup summary" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: # Manual trigger
 
 permissions:
-  packages: delete # nécessaire pour supprimer des versions
+  packages: write
   contents: read
 
 jobs:

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -13,88 +13,81 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 🧹 List & delete outdated versions for all syn2real/* packages
+      - name: 🧹 List & delete outdated versions for all ${GITHUB_REPOSITORY#*/}/* packages
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const org    = context.repo.owner
-            // Target packages under "<repo>/…"
-            const prefix = `context.repo.repo/`
+            // ① Destructure owner & repo from context
+            const { owner, repo } = context.repo;
 
-            // Flexible SemVer regex (single-line, no unsupported flags):
-            //  • optional leading "v"
-            //  • major required; minor & patch optional
-            //  • optional prerelease (-...) and build metadata (+...)
+            // ② Prefix = "<repo>/" to target only packages under this repository
+            const prefix = `${repo}/`;
+
+            // ③ Flexible SemVer (leading "v", optional minor/patch, prerelease/build)
             const semver = /^v?(0|[1-9]\d*)(\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
-            // 1️⃣ List all container packages, filter by prefix
-            let pkgPage = 1
-            const pkgNames = []
-
+            // 1️⃣ List all container packages for this repo
+            let pkgPage  = 1;
+            const pkgNames = [];
             while (true) {
               const { data: pkgs } = await github.request(
-                'GET /orgs/{org}/packages',
+                'GET /repos/{owner}/{repo}/packages',
                 {
-                  org,
+                  owner, repo,
                   package_type: 'container',
                   per_page: 100,
                   page: pkgPage
                 }
-              )
+              );
+              if (!pkgs.length) break;
 
-              if (!pkgs.length) break
-
+              // Filter to names starting with "<repo>/…"
               for (const p of pkgs) {
                 if (p.name.startsWith(prefix)) {
-                  pkgNames.push(p.name)
+                  pkgNames.push(p.name);
                 }
               }
-
-              pkgPage++
+              pkgPage++;
             }
 
-            // 2️⃣ For each matching package, list versions & delete non-SemVer/non-main
-            for (const pkg of pkgNames) {
-              let verPage = 1
-
+            // 2️⃣ For each package, purge non-SemVer & non-main versions
+            for (const pkgName of pkgNames) {
+              let verPage = 1;
               while (true) {
                 const { data: versions } = await github.request(
                   'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
                   {
-                    org,
+                    org: owner,
                     package_type: 'container',
-                    package_name: pkg,
+                    package_name: pkgName,
                     per_page: 100,
                     page: verPage
                   }
-                )
-
-                if (!versions.length) break
+                );
+                if (!versions.length) break;
 
                 for (const v of versions) {
-                  const tags = v.metadata.container.tags || []
+                  const tags = v.metadata.container.tags || [];
 
-                  // Keep if any tag matches SemVer or is 'main'
+                  // Keep if any tag matches SemVer or is literally "main"
                   if (tags.some(t => semver.test(t) || t === 'main')) {
-                    continue
+                    continue;
                   }
 
-                  // Otherwise delete it
+                  // Otherwise delete the version
                   await github.request(
                     'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
                     {
-                      org,
+                      org: owner,
                       package_type: 'container',
-                      package_name: pkg,
+                      package_name: pkgName,
                       package_version_id: v.id
                     }
-                  )
-
-                  console.log(`Deleted ${pkg}@${v.id} (tags: ${tags.join(', ')})`)
+                  );
+                  console.log(`Deleted ${pkgName}@${v.id} (tags: ${tags.join(', ')})`);
                 }
-
-                verPage++
+                verPage++;
               }
             }
 

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -17,12 +17,12 @@ jobs:
       matrix:
         service:
           - baseline
-          # - controlnet
+          - controlnet
           - blip
           - mlflow
           - deepfloyd
           - sdxl
-          # - eval
+          - eval
           - gan
 
     steps:

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -1,3 +1,10 @@
+name: 🧹 Docker registry weekly clean-Up
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at 00:00 UTC
+  workflow_dispatch: # Manual trigger
+
 permissions:
   packages: delete # nécessaire pour supprimer des versions
   contents: read

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -18,36 +18,36 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // ① Destructure owner & repo
+            // ① Destructure org and repo
             const { owner, repo } = context.repo;
-            const prefix         = `${repo}/`;  
+            const prefix          = `${repo}/`;
 
-            // ② Flexible SemVer regex:
-            //    - optional leading "v"
-            //    - major required, minor & patch optional
-            //    - optional prerelease (-…) and build metadata (+…)
+            // ② Flexible SemVer: optional "v", optional minor/patch, prerelease/build
             const semver = /^v?(0|[1-9]\d*)(\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
-            // 1️⃣ List all org packages (no package_type filter)
-            let pkgPage  = 1;
-            const allPkgs = [];
+            // 1️⃣ List all container packages (paginated)
+            let pkgPage = 1;
+            const pkgNames = [];
             while (true) {
               const { data: pkgs } = await github.request(
                 'GET /orgs/{org}/packages',
-                { org: owner, per_page: 100, page: pkgPage }
+                {
+                  org: owner,
+                  package_type: 'container',
+                  per_page: 100,
+                  page: pkgPage
+                }
               );
               if (!pkgs.length) break;
-              allPkgs.push(...pkgs);
+              // Filter to "<repo>/…" names
+              pkgs
+                .filter(p => p.name.startsWith(prefix))
+                .forEach(p => pkgNames.push(p.name));
               pkgPage++;
             }
 
-            // 2️⃣ Filter to container packages under "<repo>/…"
-            const containerPkgs = allPkgs
-              .filter(p => p.package_type === 'container' && p.name.startsWith(prefix))
-              .map(p => p.name);
-
-            // 3️⃣ For each container package, delete non‐SemVer & non‐main versions
-            for (const pkgName of containerPkgs) {
+            // 2️⃣ For each package, purge non‐SemVer & non‐main versions
+            for (const pkgName of pkgNames) {
               let verPage = 1;
               while (true) {
                 const { data: versions } = await github.request(
@@ -61,10 +61,9 @@ jobs:
                   }
                 );
                 if (!versions.length) break;
-
                 for (const v of versions) {
                   const tags = v.metadata.container.tags || [];
-                  // Keep if any tag matches semver or is "main"
+                  // Keep if any tag is SemVer or 'main'
                   if (tags.some(t => semver.test(t) || t === 'main')) continue;
                   // Otherwise delete
                   await github.request(
@@ -78,7 +77,6 @@ jobs:
                   );
                   console.log(`Deleted ${pkgName}@${v.id} (tags: ${tags.join(', ')})`);
                 }
-
                 verPage++;
               }
             }

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -18,76 +18,68 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // ① Destructure owner & repo from context
+            // ① Destructure owner & repo
             const { owner, repo } = context.repo;
+            const prefix         = `${repo}/`;
 
-            // ② Prefix = "<repo>/" to target only packages under this repository
-            const prefix = `${repo}/`;
-
-            // ③ Flexible SemVer (leading "v", optional minor/patch, prerelease/build)
+            // ② Flexible SemVer regex
             const semver = /^v?(0|[1-9]\d*)(\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
-            // 1️⃣ List all container packages for this repo
-            let pkgPage  = 1;
-            const pkgNames = [];
-            while (true) {
-              const { data: pkgs } = await github.request(
-                'GET /repos/{owner}/{repo}/packages',
-                {
-                  owner, repo,
-                  package_type: 'container',
-                  per_page: 100,
-                  page: pkgPage
+            // ③ Dynamically fetch all CONTAINER packages in the org via GraphQL
+            let pkgNames = [];
+            let cursor    = null;
+            do {
+              const q = await github.graphql(`
+                query($org: String!, $after: String) {
+                  organization(login: $org) {
+                    packages(first: 100, after: $after, types: CONTAINER) {
+                      pageInfo { endCursor, hasNextPage }
+                      nodes { name }
+                    }
+                  }
                 }
-              );
-              if (!pkgs.length) break;
+              `, { org: owner, after: cursor });
 
-              // Filter to names starting with "<repo>/…"
-              for (const p of pkgs) {
-                if (p.name.startsWith(prefix)) {
-                  pkgNames.push(p.name);
-                }
-              }
-              pkgPage++;
-            }
+              const pkgs = q.organization.packages.nodes.map(p => p.name);
+              pkgNames.push(...pkgs);
+              cursor = q.organization.packages.pageInfo.endCursor;
+              hasNext = q.organization.packages.pageInfo.hasNextPage;
+            } while (hasNext);
 
-            // 2️⃣ For each package, purge non-SemVer & non-main versions
-            for (const pkgName of pkgNames) {
-              let verPage = 1;
+            // ④ Filter to packages under "<repo>/…"
+            pkgNames = pkgNames.filter(name => name.startsWith(prefix));
+
+            // ⑤ For each pkg, delete non-SemVer & non-main versions
+            for (const pkg of pkgNames) {
+              let page = 1;
               while (true) {
                 const { data: versions } = await github.request(
                   'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
                   {
                     org: owner,
                     package_type: 'container',
-                    package_name: pkgName,
+                    package_name: pkg,
                     per_page: 100,
-                    page: verPage
+                    page
                   }
                 );
                 if (!versions.length) break;
 
                 for (const v of versions) {
                   const tags = v.metadata.container.tags || [];
-
-                  // Keep if any tag matches SemVer or is literally "main"
-                  if (tags.some(t => semver.test(t) || t === 'main')) {
-                    continue;
-                  }
-
-                  // Otherwise delete the version
+                  if (tags.some(t => semver.test(t) || t === 'main')) continue;
                   await github.request(
                     'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
                     {
                       org: owner,
                       package_type: 'container',
-                      package_name: pkgName,
+                      package_name: pkg,
                       package_version_id: v.id
                     }
                   );
-                  console.log(`Deleted ${pkgName}@${v.id} (tags: ${tags.join(', ')})`);
+                  console.log(`Deleted ${pkg}@${v.id} (tags: ${tags.join(', ')})`);
                 }
-                verPage++;
+                page++;
               }
             }
 

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -45,6 +45,8 @@ jobs:
               pkgPage++;
             }
 
+            console.log(pkgNames);
+
             // 2️⃣ For each package, purge non‐SemVer & non‐main versions
             for (const pkgName of pkgNames) {
               let verPage = 1;

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -75,13 +75,3 @@ jobs:
               }
               page++;
             }
-
-      - name: 📝 Deleted versions summary
-        run: |
-          echo "### 🗑️ Deleted versions for ${{ matrix.service }}" >> "$GITHUB_STEP_SUMMARY"
-          deleted="${{ steps.cleanup.outputs.deleted }}"
-          if [ -z "$deleted" ]; then
-            echo "- ✨ **None deleted** ✨" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "$deleted" | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
-          fi

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -13,73 +13,73 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 🧹 List & delete outdated versions for all ${GITHUB_REPOSITORY#*/}/* packages
+      - name: 🧹 Dynamic cleanup of container packages
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             // ① Destructure owner & repo
             const { owner, repo } = context.repo;
-            const prefix          = `${repo}/`;
+            const prefix         = `${repo}/`;  
 
-            // ② Flexible SemVer regex
+            // ② Flexible SemVer regex:
+            //    - optional leading "v"
+            //    - major required, minor & patch optional
+            //    - optional prerelease (-…) and build metadata (+…)
             const semver = /^v?(0|[1-9]\d*)(\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
-            // ③ Dynamically fetch all CONTAINER packages in the org via GraphQL
-            let pkgNames = [];
-            let cursor    = null;
-            do {
-              const q = await github.graphql(`
-                query($org: String!, $after: String) {
-                  organization(login: $org) {
-                    packages(first: 100, after: $after, types: CONTAINER) {
-                      pageInfo { endCursor, hasNextPage }
-                      nodes { name }
-                    }
-                  }
-                }
-              `, { org: owner, after: cursor });
+            // 1️⃣ List all org packages (no package_type filter)
+            let pkgPage  = 1;
+            const allPkgs = [];
+            while (true) {
+              const { data: pkgs } = await github.request(
+                'GET /orgs/{org}/packages',
+                { org: owner, per_page: 100, page: pkgPage }
+              );
+              if (!pkgs.length) break;
+              allPkgs.push(...pkgs);
+              pkgPage++;
+            }
 
-              const pkgs = q.organization.packages.nodes.map(p => p.name);
-              pkgNames.push(...pkgs);
-              cursor = q.organization.packages.pageInfo.endCursor;
-              hasNext = q.organization.packages.pageInfo.hasNextPage;
-            } while (hasNext);
+            // 2️⃣ Filter to container packages under "<repo>/…"
+            const containerPkgs = allPkgs
+              .filter(p => p.package_type === 'container' && p.name.startsWith(prefix))
+              .map(p => p.name);
 
-            // ④ Filter to packages under "<repo>/…"
-            pkgNames = pkgNames.filter(name => name.startsWith(prefix));
-
-            // ⑤ For each pkg, delete non-SemVer & non-main versions
-            for (const pkg of pkgNames) {
-              let page = 1;
+            // 3️⃣ For each container package, delete non‐SemVer & non‐main versions
+            for (const pkgName of containerPkgs) {
+              let verPage = 1;
               while (true) {
                 const { data: versions } = await github.request(
                   'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
                   {
                     org: owner,
                     package_type: 'container',
-                    package_name: pkg,
+                    package_name: pkgName,
                     per_page: 100,
-                    page
+                    page: verPage
                   }
                 );
                 if (!versions.length) break;
 
                 for (const v of versions) {
                   const tags = v.metadata.container.tags || [];
+                  // Keep if any tag matches semver or is "main"
                   if (tags.some(t => semver.test(t) || t === 'main')) continue;
+                  // Otherwise delete
                   await github.request(
                     'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
                     {
                       org: owner,
                       package_type: 'container',
-                      package_name: pkg,
+                      package_name: pkgName,
                       package_version_id: v.id
                     }
                   );
-                  console.log(`Deleted ${pkg}@${v.id} (tags: ${tags.join(', ')})`);
+                  console.log(`Deleted ${pkgName}@${v.id} (tags: ${tags.join(', ')})`);
                 }
-                page++;
+
+                verPage++;
               }
             }
 

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -87,7 +87,7 @@ jobs:
           echo "${{ steps.cleanup.outputs.deleted }}" > deleted.txt
 
       - name: 📦 Upload deleted entries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: deleted-entries-${{ matrix.service }}
           path: deleted.txt
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: 📥 Download all deleted‐entries artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: deleted_entries
 

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -1,13 +1,6 @@
-name: 🧹 Docker registry weekly clean-Up
-
-on:
-  schedule:
-    - cron: '0 0 * * 0' # Every Sunday at 00:00 UTC
-  workflow_dispatch: # Manual trigger
-
 permissions:
-  packages: write # <-- must be write to remove versions
-  contents: read # needed if listing repository contents
+  packages: delete # nécessaire pour supprimer des versions
+  contents: read
 
 jobs:
   cleanup:
@@ -34,11 +27,13 @@ jobs:
 
       - name: 🧹 Clean up images for ${{ matrix.service }}
         uses: actions/github-script@v7
+        env:
+          SERVICE: ${{ matrix.service }} # ← on expose la valeur ici
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            const pkgName         = `${repo}/${matrix.service}`;
+            const pkgName         = `${repo}/${process.env.SERVICE}`;
 
             // Flexible SemVer: optional "v", optional minor/patch, prerelease/build
             const semver = /^v?(0|[1-9]\d*)(\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -75,9 +75,13 @@ jobs:
               }
               page++;
             }
+
       - name: 📝 Deleted versions summary
         run: |
           echo "### 🗑️ Deleted versions for ${{ matrix.service }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "${{ steps.cleanup.outputs.deleted }}" \
-          | sed 's/^/- /' \
-          >> "$GITHUB_STEP_SUMMARY"
+          deleted="${{ steps.cleanup.outputs.deleted }}"
+          if [ -z "$deleted" ]; then
+            echo "- ✨ **None deleted** ✨" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "$deleted" | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -1,56 +1,77 @@
-name: 🧹 Docker registry weekly clean-up
+name: 🧹 Docker registry weekly clean-Up
 
 on:
   schedule:
     - cron: '0 0 * * 0' # Every Sunday at 00:00 UTC
-  workflow_dispatch:
+  workflow_dispatch: # Manual trigger
 
 permissions:
-  packages: write # Allow deleting package versions
+  packages: write # Needed to delete versions
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - baseline
+          - controlnet
+          - blip
+          - mlflow
+          - deepfloyd
+          - sdxl
+          - eval
+          - gan
 
     steps:
-      - name: 🧹 Dynamic cleanup of container packages
+      - name: 🐳 Checkout code
+        uses: actions/checkout@v3
+
+      - name: 🔒 Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🧹 Clean up images for ${{ matrix.service }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // ① Destructure org and repo
             const { owner, repo } = context.repo;
-            const prefix          = `${repo}/`;
+            const pkgName         = `${repo}/${matrix.service}`;
 
-            // ② Flexible SemVer: optional "v", optional minor/patch, prerelease/build
+            // Flexible SemVer: optional "v", optional minor/patch, prerelease/build
             const semver = /^v?(0|[1-9]\d*)(\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
-            // 1️⃣ List all container packages (paginated)
-            let pkgPage = 1;
-            const pkgNames = [];
+            let page = 1;
             while (true) {
-              const { data: pkgs } = await github.request(
-                'GET /orgs/{org}/packages',
+              const { data: versions } = await github.request(
+                'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
                 {
                   org: owner,
                   package_type: 'container',
-                  page: pkgPage
+                  package_name: pkgName,
+                  per_page: 100,
+                  page
                 }
               );
-              if (!pkgs.length) break;
-              // Filter to "<repo>/…" names
-              pkgs
-                .filter(p => p.name.startsWith(prefix))
-                .forEach(p => pkgNames.push(p.name));
-              pkgPage++;
+              if (!versions.length) break;
+
+              for (const v of versions) {
+                const tags = v.metadata.container.tags || [];
+                if (tags.some(t => semver.test(t) || t === 'main')) continue;
+                await github.request(
+                  'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
+                  {
+                    org: owner,
+                    package_type: 'container',
+                    package_name: pkgName,
+                    package_version_id: v.id
+                  }
+                );
+                console.log(`Deleted ${pkgName}@${v.id} (tags: ${tags.join(', ')})`);
+              }
+              page++;
             }
-
-            console.log(pkgNames);
-
-      - name: 📝 Cleanup job summary
-        run: |
-          echo "### 🧹 Docker registry cleanup summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ✅ Kept tags matching **flexible SemVer** (optional leading 'v', optional minor/patch, prerelease/build-metadata)" \
-               >> "$GITHUB_STEP_SUMMARY"
-          echo "- ✅ Preserved any version tagged **main**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- 🗑️  Deleted all other container versions" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -75,3 +75,9 @@ jobs:
               }
               page++;
             }
+      - name: 📝 Deleted versions summary
+        run: |
+          echo "### 🗑️ Deleted versions for ${{ matrix.service }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.cleanup.outputs.deleted }}" \
+          | sed 's/^/- /' \
+          >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/clean-registry.yml
+++ b/.github/workflows/clean-registry.yml
@@ -121,7 +121,7 @@ jobs:
               svc_version=$2
               split($0, a, "@"); svc=a[1]
               # gather lines per service
-              lines[svc] = lines[svc] "\n- **" svc_version
+              lines[svc] = lines[svc] "\n- " svc_version
             }
             END {
               for (s in lines) {


### PR DESCRIPTION
**ℹ Requirements:**
We need to automatically purge old container tags that aren’t SemVer-compliant or `main`, and ensure our build workflow can parallelize all services via a matrix.

**💬 Feature description:**
- **Matrix Cleanup Job**  
  - Added a `cleanup` job with a **GitHub Actions matrix** of services (`baseline`, `controlnet`, `blip`, `mlflow`, `deepfloyd`, `sdxl`, `eval`, `gan`).  
  - Each step authenticates to GHCR, lists versions for `repo/${SERVICE}`, and deletes any tag not matching our flexible SemVer pattern or `main`.  
  - Exposed `SERVICE` via `env` so `actions/github-script` can reference `process.env.SERVICE` without `matrix` lookup errors.

- **Build Matrix Fix**  
  - Ensured all build jobs pass `REPO_URL` (with `GITHUB_TOKEN` or SSH) as a build arg to avoid “repository not found” during `git clone`.  
  - Switched `permissions: packages: delete` so cleanup has the required scope to remove package versions.


**🧪 How to test:**
1. **Build Workflow**  
   - Merge to `main` or trigger `workflow_dispatch`.  
   - Verify **8 parallel build jobs** run (`baseline…gan`) and push images to `ghcr.io/<org>/<repo>/<service>:<tag>`.  
   - Confirm Dockerfiles clone the repo successfully using the injected `REPO_URL`.

2. **Cleanup Workflow**  
   - Trigger manually or wait for the next Sunday at 00:00 UTC.  
   - In GHCR, confirm:
     - **Only** tags matching SemVer (e.g. `1`, `1.2`, `v1.2.3`, `2.0.0-rc.1+build`) or `main` remain.
     - All ad-hoc tags (e.g. `test-xyz`, commit hashes, etc.) are deleted.

3. **Logs & Summary**  
   - Check workflow logs for `Deleted <service>@<version>` entries.  
   - Verify the **job summary** bullet points correctly reflect which tags were kept vs. removed.


**🚨 IMPORTANT:**
- The **cleanup workflow** now runs under `packages: delete`. Please ensure the repository’s GHCR settings grant the **GITHUB_TOKEN** admin access to packages.  
- This cleanup will only execute **after** merging this PR—monitor the **first run** carefully to avoid unintended deletions.  
- If you need to exempt any service temporarily, update the matrix or add a conditional in the script before merging.  
